### PR TITLE
add compilation.yml to enable CI

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,0 +1,34 @@
+name: CI-compile
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: tobix/mipsr5900el-toolchain:latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch --prune --unshallow
+
+    - name: Compile project
+      run: make
+
+    - name: Get short SHA
+      id: version
+      run: echo "::set-output name=version::$(git rev-parse --short HEAD)"
+
+    - name: Prepare artifacts for release
+      run: |
+        tar -czvf iopmod-modules-${{ steps.version.outputs.version }}.tar.gz module/*.irx
+
+    - name: Create release
+      if: github.ref == 'refs/heads/master'
+      uses: marvinpinto/action-automatic-releases@latest
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: true
+        automatic_release_tag: "latest"
+        title: "${{ steps.version.outputs.version }}"
+        files: iopmod-modules-${{ steps.version.outputs.version }}.tar.gz


### PR DESCRIPTION
A first step for CI. Since iopmod modules are incompatible with latest gcc i use (11.2.0), it allows me to use the old toolchain for this stuff.